### PR TITLE
Filter logstreams by time range before getting log events 

### DIFF
--- a/main.go
+++ b/main.go
@@ -47,7 +47,7 @@ func groupsCompletion() []string {
 
 func streamsCompletion() []string {
 	var streams []string
-	for msg := range cloudwatch.LsStreams(logGroupName, nil) {
+	for msg := range cloudwatch.LsStreams(logGroupName, nil, 0, 0) {
 		streams = append(streams, *msg)
 	}
 	return streams
@@ -128,7 +128,7 @@ func main() {
 			fmt.Println(*msg)
 		}
 	case "ls streams":
-		for msg := range cloudwatch.LsStreams(lsLogGroupName, nil) {
+		for msg := range cloudwatch.LsStreams(lsLogGroupName, nil, 0, 0) {
 			fmt.Println(*msg)
 		}
 	case "tail":


### PR DESCRIPTION
When using a logstream prefix the maximum number of logstreams that log events can be obtained for is 100. In case that the number of logstreams matching the prefix is larger than 100, filtering out only the relevant streams for a given time range, can help to stay below the limit.