### PR TITLE
Add 2FA support

### DIFF
--- a/main.go
+++ b/main.go
@@ -64,6 +64,7 @@ var (
 	grep  = tailCommand.Flag("grep", "Pattern to filter logs by. See http://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/FilterAndPatternSyntax.html for syntax.").
 		Short('g').Default("").String()
 	grepv = tailCommand.Flag("grepv", "Equivalent of grep --invert-match. Invert match pattern to filter logs by.").Short('v').Default("").String()
+	mfa = kp.Flag("mfa", "When target AWS profile has MFA enabled.").Short('m').Default("false").Bool()
 )
 
 func timestampToTime(timeStamp *string) (time.Time, error) {
@@ -173,7 +174,7 @@ func main() {
 		color.NoColor = true
 	}
 
-	c := cloudwatch.New(awsProfile, awsRegion, log)
+	c := cloudwatch.New(awsProfile, awsRegion, mfa, log)
 
 	switch cmd {
 	case "ls groups":


### PR DESCRIPTION
In re #47 , I have implement 2FA support by adding new Flag named `mfa` or `m` for short. It is boolean type, indicating either default profile or named profile provided via `profile` flag has MFA enabled. 

Implementation sets Session Options field `AssumeRoleTokenProvider` with `stscreds.StdinTokenProvider` and also set duration for this session as 1 hour, the duration can be provided via user input with `duration` flag but for now it is hard coded. I can change that if needed.

Note: 2FA will only work here for IAM Role that have 2FA enabled.