### PR TITLE
Update lastSeenTimestamp to event time +1ms to avoid re-fetching same events

### DIFF
--- a/cloudwatch/tail.go
+++ b/cloudwatch/tail.go
@@ -130,16 +130,11 @@ func (cwl *CW) Tail(logGroupName *string, logStreamName *string, follow *bool, s
 	}
 
 	go func() {
-		t := time.NewTicker(time.Millisecond * 100)
-		for range t.C {
+		for range limiter {
 			if lastSeenEvent != nil {
 				lastSeenTimestamp = *lastSeenEvent.Timestamp + 1
 			}
-		}
-	}()
 
-	go func() {
-		for range limiter {
 			select {
 			case <-idle:
 				logParam := params(*logGroupName, logStreams.get(), lastSeenTimestamp, endTimeInMillis, grep, follow)


### PR DESCRIPTION
#### What's the problem?
When running in `-f` follow mode `tail.go` polls cloudwatch every ~205ms for logs and checks against a cache to ignore seen events. Most of the time the cache is hit and the event correctly ignored, but when the cache is emptied (every ~70 secs) we get a repeat of any events that occurred at the same time as the last event (for events with timestamp diff > 1ms this manifests as logging the last event over and over again). This isn't ideal.

#### Why does it happen?
Whenever `tail.go` receives a new event it sets `lastSeenTimestamp` to be the timestamp of the event, then  `lastSeenTimestamp` is used as the `Start` parameter to `FilterLogEventsPages`. This means we're constantly (every 205ms) going to get events starting at the same time as the last event and AWS happily gives us back that event every time, eventually the cache expires, tail thinks it's a new event and logs it.

#### What's this fix?
The simple solution is to change the line that calls `params` and give it `lastSeenTimestamp + 1` as the start argument. Tbh that might work (and I'm not 100% sure how Cloudwatch works) but if we have loads of events all happening at the same ms I'm worried it might not include all events in one batch, which means when we hit the `idle` trigger second time around we'd be starting at `lastSeenTimestamp + 1ms` which would miss the remaining events.

Instead I now save the `lastSeenEvent` and set the `lastSeenTimestamp` to `event.Timestamp + 1` inside the `limiter` iterator. This ensures we won't miss events occurring at the same ms but is short enough to not cause lag in the output. Also added benefit of not spamming the `pageHandler` function every 205ms.