### PR TITLE
Fixes SIGSEGV when a LogStream is missing LastIngestionTime

### DIFF
--- a/cloudwatch/lsstreams.go
+++ b/cloudwatch/lsstreams.go
@@ -21,7 +21,18 @@ func (cwl *CW) LsStreams(groupName *string, streamName *string) <-chan *string {
 	}
 	handler := func(res *cloudwatchlogs.DescribeLogStreamsOutput, lastPage bool) bool {
 		sort.SliceStable(res.LogStreams, func(i, j int) bool {
-			return *res.LogStreams[i].LastIngestionTime < *res.LogStreams[j].LastIngestionTime
+			var streamALastIngestionTime int64 = 0;
+			var streamBLastIngestionTime int64 = 0;
+
+			if ingestionTime := res.LogStreams[i].LastIngestionTime; ingestionTime != nil {
+				streamALastIngestionTime = *ingestionTime;
+			}
+
+			if ingestionTime := res.LogStreams[j].LastIngestionTime; ingestionTime != nil {
+				streamBLastIngestionTime = *ingestionTime;
+			}
+
+			return streamALastIngestionTime < streamBLastIngestionTime;
 		})
 
 		for _, logStream := range res.LogStreams {


### PR DESCRIPTION
`LastIngestionTime` might be absent (i.e. point to `nil`) in a `LogStream`. Dereferencing it then causes a SIGSEGV. This commit changes the sort comparison function to default to 0 if no `LastIngestionTime` is available.

Fixes #44 