### PR TITLE
Change the Debian package name to cw-tail to avoid conflict

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -78,12 +78,26 @@ nfpms:
     license: Apache2
     vendor: cw
     formats:
-    - deb
     - rpm
     dependencies:
     - git
     recommends:
     - rpm
+  -
+    package_name: cw-tail  # Use the package name "cw-tail" to avoid conflicts with https://launchpad.net/ubuntu/bionic/amd64/cw
+    replaces:
+    - cw (<< 3.3.0)
+    file_name_template: '{{ .ProjectName }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'
+    homepage:  https://www.lucagrulla.com/cw
+    description: The best way to tail AWS Cloudwatch Logs from your terminal
+    maintainer: Luca Grulla luca.grulla+cw@gmail.com
+    license: Apache2
+    vendor: cw
+    formats:
+    - deb
+    dependencies:
+    - git
+
 snapcrafts:
   -
     name: cw-sh


### PR DESCRIPTION
This changes the Debian package name from cw to cw-tail to avoid
conflicting with the pre-existing Ubuntu Debian package, "cw"

https://packages.ubuntu.com/bionic/cw

This change changes the package name and configures the package to
replace versions of "cw" of 3.3.0 or earlier.

cw, the CloudWatch tailing tool, has a newest version of 3.3.0
cw, the Morse code tutor, has an oldest current version of 3.4.2-1build1

Fixes #134