### PR TITLE
Filter "tail" streams by last ingestion time

### DIFF
--- a/cloudwatch/tail.go
+++ b/cloudwatch/tail.go
@@ -73,7 +73,7 @@ func (cwl *CW) Tail(logGroupName *string, logStreamName *string, follow *bool, s
 	if logStreamName != nil && *logStreamName != "" {
 		getStreams := func(logGroupName *string, logStreamName *string) []*string {
 			var streams []*string
-			for stream := range cwl.LsStreams(logGroupName, logStreamName) {
+			for stream := range cwl.LsStreams(logGroupName, logStreamName, &lastSeenTimestamp) {
 				streams = append(streams, stream)
 			}
 			if len(streams) == 0 {
@@ -100,7 +100,6 @@ func (cwl *CW) Tail(logGroupName *string, logStreamName *string, follow *bool, s
 	pageHandler := func(res *cloudwatchlogs.FilterLogEventsOutput, lastPage bool) bool {
 		for _, event := range res.Events {
 			if *grepv == "" || !re.MatchString(*event.Message) {
-
 				if !cache.Has(*event.EventId) {
 					eventTimestamp := *event.Timestamp
 

--- a/main.go
+++ b/main.go
@@ -183,7 +183,7 @@ func main() {
 			fmt.Println(*msg)
 		}
 	case "ls streams":
-		for msg := range c.LsStreams(lsLogGroupName, nil) {
+		for msg := range c.LsStreams(lsLogGroupName, nil, nil) {
 			fmt.Println(*msg)
 		}
 	case "tail":


### PR DESCRIPTION
I noticed that if I had a log stream prefix with a lot of matches (hundreds of matching stream names), I would get no results pulling logs, even if there was an active recent stream under that prefix. I believe that this is due to the fact that the `Tail` function truncates the stream list to the first 100 pulled back from `LsStreams`. This PR filters the output of `LsStreams` so that it only returns back streams with a `LastIngestedTime` more recent than the `StartTime` when called from `Tail`.

I had also looked at sorting the log stream names by `LastIngestedTime` in reverse order, however, the stream names come back in pages, and each page is sorted in isolation before its entries are put in the output channel.

I am hoping this does not have any adverse effects on "unfiltered" use cases I'm not aware of; please let me know your thoughts.