### PR TITLE
Add jmespath support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,9 @@
 
 ![cw - the best way to tail AWS CloudWatch Logs](https://github.com/lucagrulla/cw/raw/master/images/cw-logo1280x640.png)
 
-
 The **best** way to tail AWS CloudWatch Logs from your terminal.
 
-Author - [Luca Grulla](https://www.lucagrulla.com)  - [https://www.lucagrulla.com](https://www.lucagrulla.com)
+Author - [Luca Grulla](https://www.lucagrulla.com) - [https://www.lucagrulla.com](https://www.lucagrulla.com)
 
 
 * [Features](##features)
@@ -23,27 +22,28 @@ Author - [Luca Grulla](https://www.lucagrulla.com)  - [https://www.lucagrulla.co
 
 ## Features
 
-* **No external dependencies** 
-  * cw is a native executable targeting your OS. No pip, npm, rubygems.
-* **Fast**. 
-  * cw is written in golang and compiled against your architecture.
-* **Flexible date and time parser**.
-  * Work with either `Local` timezone or `UTC` (default).
-  * Flexible parsing.
-    * Human friendly formats, i.e. `2d1h20m` to indicate 2 days, 1 hour and 20 minutes ago.
-    * a specific hour, i.e. `13:10` to indicate 13:10 of today.
-    * a full timestamp `2018-10-20T8:53`.
-* **Multi log groups tailing**
-   * tail multiple log groups  in parallel: `cw tail my-auth-service my-web`.
-* Powerful built-in **grep** (`--grep`) and **grepv** (`--grepv`).
-* **Pipe operator** supported  
-   * `echo my-group | cw tail` and `cat groups.txt | cw tail`. 
-* **Redirection operator >>** supported 
-   * `cw tail -f my-stream >> myfile.txt`.
-* Coloured output
-   * `--no-color` flag to disable if needed.
-* Flexible credentials control.
-   * By default the **AWS .aws/credentials and .aws/profile** files are used. Overrides can be achieved with the  `--profile` and `--region` flags.
+-   **No external dependencies**
+    -   cw is a native executable targeting your OS. No pip, npm, rubygems.
+-   **Fast**.
+    -   cw is written in golang and compiled against your architecture.
+-   **Flexible date and time parser**.
+    -   Work with either `Local` timezone or `UTC` (default).
+    -   Flexible parsing.
+        -   Human friendly formats, i.e. `2d1h20m` to indicate 2 days, 1 hour and 20 minutes ago.
+        -   a specific hour, i.e. `13:10` to indicate 13:10 of today.
+        -   a full timestamp `2018-10-20T8:53`.
+-   **Multi log groups tailing**
+    -   tail multiple log groups in parallel: `cw tail my-auth-service my-web`.
+-   Powerful built-in **grep** (`--grep`) and **grepv** (`--grepv`).
+-   [JMESPath](https://jmespath.org/) support for JSON queries (matching the [AWS CLI `--query`](https://docs.aws.amazon.com/cli/latest/userguide/cli-usage-filter.html#cli-usage-filter-client-side) flag)
+-   **Pipe operator** supported
+    -   `echo my-group | cw tail` and `cat groups.txt | cw tail`.
+-   **Redirection operator >>** supported
+    -   `cw tail -f my-stream >> myfile.txt`.
+-   Coloured output
+    -   `--no-color` flag to disable if needed.
+-   Flexible credentials control.
+    -   By default the **AWS .aws/credentials and .aws/profile** files are used. Overrides can be achieved with the `--profile` and `--region` flags.
 
 ## Installation
 
@@ -67,10 +67,12 @@ brew install cw
 
 #### .deb/.rpm
 
-Download the ```.deb``` or ```.rpm``` from the [releases page](https://github.com/lucagrulla/cw/releases/latest) and install with ````dpkg -i```` and ````rpm -i```` respectively.
+Download the `.deb` or `.rpm` from the [releases page](https://github.com/lucagrulla/cw/releases/latest) and install with `dpkg -i` and `rpm -i` respectively.
 
 #### using [Snapcraft.io](https://snapcraft.io)
-*Note*: If you upgrade to 3.3.0 please note the new alias command.This is required to comply with snapcraft new release rules.
+
+_Note_: If you upgrade to 3.3.0 please note the new alias command. This is required to comply with snapcraft new release rules.
+
 ```bash
 snap install cw-sh
 sudo snap connect cw-sh:dot-aws-config-credentials
@@ -100,106 +102,122 @@ go get github.com/lucagrulla/cw
 
 ### Global flags
 
-* `--profile=profile-name` Override the AWS profile used for connection.
-* `--region=aws-region` Override the target AWS region.
-* `--no-color`         Disable coloured output.
-* `--endpooint`         The target AWS endpoint url. By default cw will use the default aws endpoints.
+-   `--profile=profile-name` Override the AWS profile used for connection.
+-   `--region=aws-region` Override the target AWS region.
+-   `--no-color` Disable coloured output.
+-   `--endpoint` The target AWS endpoint url. By default cw will use the default aws endpoints.
 
 ### Commands
 
-* `cw ls` list all the log groups/log streams within a group
-    ```console
-    usage: cw ls <command> [<args> ...]
+-   `cw ls` list all the log groups/log streams within a group
 
-    Show an entity
+    ```console
+    Usage: cw ls <command>
+
+    show an entity
 
     Flags:
-        --help             Show context-sensitive help (also try --help-long and --help-man).
-        --profile=PROFILE  The target AWS profile. By default cw will use the default profile defined in the .aws/credentials file.
-        --region=REGION    The target AWS region.. By default cw will use the default region defined in the .aws/credentials file.
-        --endpoint=ENDPOINT-URL The target AWS endpoint url. By default cw will use the default aws
-                         endpoints.
-    -c, --no-color         Disable coloured output.
-        --version          Show application version.
+      -h, --help               Show context-sensitive help.
+          --endpoint=URL       The target AWS endpoint url. By default cw will use the default aws endpoints. NOTE: v4.0.0
+                              dropped the flag short version.
+          --profile=PROFILE    The target AWS profile. By default cw will use the default profile defined in the
+                              .aws/credentials file. NOTE: v4.0.0 dropped the flag short version.
+          --region=REGION      The target AWS region. By default cw will use the default region defined in the
+                              .aws/credentials file. NOTE: v4.0.0 dropped the flag short version.
+          --no-color           Disable coloured output.NOTE: v4.0.0 dropped the flag short version.
+          --version            Print version information and quit
 
-    Subcommands:
-    ls groups
+    Commands:
+      ls groups
         Show all groups.
 
-    ls streams <group>
-        Show all streams in a given log group.
+      ls streams <group>
+        how all streams in a given log group.
+
+    cw: error: expected one of "groups",  "streams"
     ```
-* `cw tail` tail a given log group/log stream
+
+-   `cw tail` tail a given log group/log stream
+
     ```console
-        usage: cw tail [<flags>] <groupName:logStreamPrefix...>...
+    Usage: cw tail <groupName[:logStreamPrefix]> ...
 
-        Tail log groups/streams.
+    Tail log groups/streams.
 
-        Flags:
-            --help             Show context-sensitive help (also try --help-long and --help-man).
-            --profile=PROFILE  The target AWS profile. By default cw will use the default profile defined in the .aws/credentials file.
-            --region=REGION    The target AWS region. By default cw will use the default region defined in the .aws/credentials file.
-            --no-color         Disable coloured output.
-            --version          Show application version.
-        -f, --follow           Don't stop when the end of streams is reached, but rather wait for additional data to be appended.
-        -t, --timestamp        Print the event timestamp.
-        -i, --event-id         Print the event Id.
-        -s, --stream-name      Print the log stream name this event belongs to.
-        -n, --group-name       Print the log log group name this event belongs to.
-        -b, --start="2018-12-25T09:34:45"
-                               The UTC start time. Passed as either date/time or human-friendly format. The human-friendly format accepts the number of days, hours and minutes prior to the present. Denote days with
-                               'd', hours with 'h' and minutes with 'm' i.e. 80m, 4h30m, 2d4h. If just time is used (format: hh[:mm]) it is expanded to today at the given time. Full available date/time format:
-                               2017-02-27[T09[:00[:00]].
-        -e, --end=""           The UTC end time. Passed as either date/time or human-friendly format. The human-friendly format accepts the number of days, hours and minutes prior to the present. Denote days with
-                               'd', hours with 'h' and minutes with 'm' i.e. 80m, 4h30m, 2d4h. If just time is used (format: hh[:mm]) it is expanded to today at the given time. Full available date/time format:
-                               2017-02-27[T09[:00[:00]].
-        -l, --local            Treat date and time in Local timezone.
-        -r --retry             Keep trying to open a log group/log stream if it is inaccessible.
-        -g, --grep=""          Pattern to filter logs by. See http://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/FilterAndPatternSyntax.html for syntax.
-        -v, --grepv=""         Equivalent of grep --invert-match. Invert match pattern to filter logs by.
+    Arguments:
+      <groupName[:logStreamPrefix]> ...    The log group and stream name, with group:prefix syntax. Stream name can be just the prefix. If no stream name is specified all stream names in the given
+                                          group will be tailed. Multiple group/stream tuple can be passed. e.g. cw tail group1:prefix1 group2:prefix2 group3:prefix3.
 
-        Args:
-        <groupName:logStreamPrefix...>
-            The log group and stream name, with group:prefix syntax.Stream name can be just the prefix. If no stream name is specified all stream names in the given group will be tailed.Multiple group/stream
-            tuple can be passed. e.g. cw tail group1:prefix group2:prefix group3:prefix.     
+    Flags:
+      -h, --help                           Show context-sensitive help.
+          --endpoint=URL                   The target AWS endpoint url. By default cw will use the default aws endpoints. NOTE: v4.0.0 dropped the flag short version.
+          --profile=PROFILE                The target AWS profile. By default cw will use the default profile defined in the .aws/credentials file. NOTE: v4.0.0 dropped the flag short version.
+          --region=REGION                  The target AWS region. By default cw will use the default region defined in the .aws/credentials file. NOTE: v4.0.0 dropped the flag short version.
+          --no-color                       Disable coloured output.NOTE: v4.0.0 dropped the flag short version.
+          --version                        Print version information and quit
+
+      -f, --follow                         Don't stop when the end of streams is reached, but rather wait for additional data to be appended.
+      -t, --timestamp                      Print the event timestamp.
+      -i, --event-id                       Print the event Id.
+      -s, --stream-name                    Print the log stream name this event belongs to.
+      -n, --group-name                     Print the log group name this event belongs to.
+      -r, --retry                          Keep trying to open a log group/log stream if it is inaccessible.
+      -b, --start="2021-04-11T08:21:52"    The UTC start time. Passed as either date/time or human-friendly format. The human-friendly format accepts the number of days, hours and minutes prior to
+                                          the present. Denote days with 'd', hours with 'h' and minutes with 'm' i.e. 80m, 4h30m, 2d4h. If just time is used (format: hh[:mm]) it is expanded to
+                                          today at the given time. Full available date/time format: 2017-02-27[T09[:00[:00]].
+      -e, --end=STRING                     The UTC end time. Passed as either date/time or human-friendly format. The human-friendly format accepts the number of days, hours and minutes prior to the
+                                          present. Denote days with 'd', hours with 'h' and minutes with 'm' i.e. 80m, 4h30m, 2d4h. If just time is used (format: hh[:mm]) it is expanded to today at
+                                          the given time. Full available date/time format: 2017-02-27[T09[:00[:00]].
+      -l, --local                          Treat date and time in Local timezone.
+      -g, --grep=STRING                    Pattern to filter logs by. See http://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/FilterAndPatternSyntax.html for syntax.
+      -v, --grepv=STRING                   Equivalent of grep --invert-match. Invert match pattern to filter logs by.
+      -q, --query=STRING                   Equivalent of the --query flag in AWS CLI. Takes a JMESPath expression to filter JSON logs by. If the query fails (e.g. the log message was not JSON) then the original line is returned.
     ```
 
 ## Examples
 
-* list of the available log groups
-  * `cw ls groups`
-* list of the log streams in a given log group
-  * `cw ls streams my-log-group`
-* tail and follow given log groups/streams
-  * `cw tail -f my-log-group`
-  * `cw tail -f my-log-group:my-log-stream-prefix`
-  * `cw tail -f my-log-group:my-log-stream-prefix my-log-group2`
-  * `cw tail -f my-log-group:my-log-stream-prefix -b2017-01-01T08:10:10 -e2017-01-01T08:05:00`  
-  * `cw tail -f my-log-group:my-log-stream-prefix -b7d` to start from 7 days ago.
-  * `cw tail -f my-log-group:my-log-stream-prefix -b3h` to start from 3 hours ago.
-  * `cw tail -f my-log-group:my-log-stream-prefix -b100m`  to start from 100 minutes ago.
-  * `cw tail -f my-log-group:my-log-stream-prefix -b2h30m`  to start from 2 hours and 30 minutes ago.
-  * `cw tail -f my-log-group -b9:00 -e9:01`
+-   list of the available log groups
+    -   `cw ls groups`
+-   list of the log streams in a given log group
+    -   `cw ls streams my-log-group`
+-   tail and follow given log groups/streams
+
+    -   `cw tail -f my-log-group`
+    -   `cw tail -f my-log-group:my-log-stream-prefix`
+    -   `cw tail -f my-log-group:my-log-stream-prefix my-log-group2`
+    -   `cw tail -f my-log-group:my-log-stream-prefix -b2017-01-01T08:10:10 -e2017-01-01T08:05:00`
+    -   `cw tail -f my-log-group:my-log-stream-prefix -b7d` to start from 7 days ago.
+    -   `cw tail -f my-log-group:my-log-stream-prefix -b3h` to start from 3 hours ago.
+    -   `cw tail -f my-log-group:my-log-stream-prefix -b100m` to start from 100 minutes ago.
+    -   `cw tail -f my-log-group:my-log-stream-prefix -b2h30m` to start from 2 hours and 30 minutes ago.
+    -   `cw tail -f my-log-group -b9:00 -e9:01`
+
+-   query JSON logs using [JMESPath](https://jmespath.org/) syntax
+    -   `cw tail -f my-log-group --query "machines[?state=='running'].name"`
 
 ## Time and Dates
 
 Time and dates are treated as UTC by default.
-Use the ```--local``` flag if you prefer to use Local zone.
+Use the `--local` flag if you prefer to use Local zone.
 
 ## AWS credentials and configuration
 
 `cw` uses the default credentials profile (stored in ./aws/credentials) for authentication and shared config (.aws/config) for identifying the target AWS region. Both profile and region are overridable via the `profile` and `region` global flags.
 
 ### AWS SSO
-As today (May 2020) AWS Go SDK is not supporting AWS SSO correctly. 
+
+As today (May 2020) AWS Go SDK is not supporting AWS SSO correctly.
 The best approach is to use one of these tools while the SDK is updated:
-https://github.com/benkehoe/aws-sso-credential-process
-https://github.com/victorskl/yawsso
+<https://github.com/benkehoe/aws-sso-credential-process>
+<https://github.com/victorskl/yawsso>
 
 ## Miscellaneous
+
 ### Use `cw` behind a proxy
-Please use ```HTTP_PROXY``` environment variable as required by AWS cli:
-https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-proxy.html
+
+Please use `HTTP_PROXY` environment variable as required by AWS cli:
+<https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-proxy.html>
 
 ## Breaking changes notes
+
 Read [here](https://github.com/lucagrulla/cw/wiki/Breaking-changes-notes)

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.1.2
 	github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.1.2
 	github.com/fatih/color v1.10.0
+	github.com/jmespath/go-jmespath v0.4.0
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/stretchr/testify v1.7.0
 	golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f // indirect

--- a/go.sum
+++ b/go.sum
@@ -25,7 +25,9 @@ github.com/fatih/color v1.10.0 h1:s36xzo75JdqLaaWoiEHk767eHiwo0598uUxyfiPkDsg=
 github.com/fatih/color v1.10.0/go.mod h1:ELkj/draVOlAH/xkhN6mQ50Qd0MPOk5AAr3maGEBuJM=
 github.com/google/go-cmp v0.5.4 h1:L8R9j+yAqZuZjsqh/z+F1NCffTKKLShY6zXTItVIZ8M=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
+github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/mattn/go-colorable v0.1.8 h1:c1ghPdyEDarC70ftn0y+A/Ee++9zz8ljHG1b13eJ0s8=
 github.com/mattn/go-colorable v0.1.8/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
@@ -48,6 +50,7 @@ golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IV
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/main.go
+++ b/main.go
@@ -97,7 +97,7 @@ type logEventFormatter struct {
 }
 
 // jmespathQuery returns a the stringified results of a pre-compiled JMESPath query
-// if the query fails, it will returnt he original string.
+// if the query fails, it will return the original string.
 func (f logEventFormatter) jmespathQuery(s string, query jmespath.JMESPath) string {
 	var data interface{}
 	err := json.Unmarshal([]byte(s), &data)

--- a/main.go
+++ b/main.go
@@ -106,6 +106,9 @@ func (f logEventFormatter) jmespathQuery(s string, query jmespath.JMESPath) stri
 		f.Log.Printf("Failed query using jmespathQuery: Error: %v\n", err)
 		return s
 	}
+	if result == nil {
+		return fmt.Sprintf("<cw: empty jmesPath query result> %s", s)
+	}
 	searchResult, err := json.Marshal(result)
 	if err != nil {
 		f.Log.Printf("Failed to marshall jmespathQuery result to json: Error: %v\n", err)

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bufio"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -20,6 +21,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs/types"
 
 	"github.com/fatih/color"
+	"github.com/jmespath/go-jmespath"
 	"github.com/lucagrulla/cw/cloudwatch"
 )
 
@@ -81,20 +83,56 @@ type logEvent struct {
 	logGroup string
 }
 
-func formatLogMsg(ev logEvent, printTime *bool, printStreamName *bool, printGroupName *bool, printEventID *bool) string {
+type formatConfig struct {
+	PrintTime       bool
+	PrintStreamName bool
+	PrintGroupName  bool
+	PrintEventID    bool
+	Query           *jmespath.JMESPath
+}
+
+type logEventFormatter struct {
+	Log          *log.Logger
+	FormatConfig formatConfig
+}
+
+// jmespathQuery returns a the stringified results of a pre-compiled JMESPath query
+// if the query fails, it will returnt he original string.
+func (f logEventFormatter) jmespathQuery(s string, query jmespath.JMESPath) string {
+	var data interface{}
+	err := json.Unmarshal([]byte(s), &data)
+	result, err := query.Search(data)
+	if err != nil {
+		f.Log.Printf("Failed query using jmespathQuery: Error: %v\n", err)
+		return s
+	}
+	searchResult, err := json.Marshal(result)
+	if err != nil {
+		f.Log.Printf("Failed to marshall jmespathQuery result to json: Error: %v\n", err)
+		return s
+	}
+	return string(searchResult)
+}
+
+func (f logEventFormatter) formatLogMsg(ev logEvent) string {
 	msg := *ev.logEvent.Message
-	if *printEventID {
+
+	if f.FormatConfig.Query != nil {
+		msg = f.jmespathQuery(msg, *f.FormatConfig.Query)
+	}
+
+	if f.FormatConfig.PrintEventID {
 		msg = fmt.Sprintf("%s - %s", color.YellowString(*ev.logEvent.EventId), msg)
 	}
-	if *printStreamName {
+	if f.FormatConfig.PrintStreamName {
 		msg = fmt.Sprintf("%s - %s", color.BlueString(*ev.logEvent.LogStreamName), msg)
 	}
 
-	if *printGroupName {
+	if f.FormatConfig.PrintGroupName {
 		msg = fmt.Sprintf("%s - %s", color.CyanString(ev.logGroup), msg)
 	}
 
-	if *printTime {
+	if f.FormatConfig.PrintTime {
 		eventTimestamp := *ev.logEvent.Timestamp / 1000
 		ts := time.Unix(eventTimestamp, 0).Format(timeFormat)
 		msg = fmt.Sprintf("%s - %s", color.GreenString(ts), msg)
@@ -120,10 +158,10 @@ func fromStdin() []string {
 	return groups
 }
 
-type context struct {
-	Debug  bool
-	Client cloudwatchlogs.Client
-	Log    *log.Logger
+type appContext struct {
+	Debug    bool
+	Client   cloudwatchlogs.Client
+	DebugLog *log.Logger
 }
 
 type lsGroupsCmd struct {
@@ -145,9 +183,10 @@ type tailCmd struct {
 	Local              bool     `name:"local" help:"Treat date and time in Local timezone." short:"l" default:"false"`
 	Grep               string   `name:"grep" help:"Pattern to filter logs by. See http://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/FilterAndPatternSyntax.html for syntax." short:"g" default:""`
 	Grepv              string   `name:"grepv" help:"Equivalent of grep --invert-match. Invert match pattern to filter logs by." short:"v" default:""`
+	Query              string   `name:"query" help:"Equivalent of the --query flag in AWS CLI. Takes a JMESPath expression to filter JSON logs by." short:"q" default:""`
 }
 
-func (t *tailCmd) Run(ctx *context) error {
+func (t *tailCmd) Run(ctx *appContext) error {
 	if additionalInput := fromStdin(); additionalInput != nil {
 		t.LogGroupStreamName = append(t.LogGroupStreamName, additionalInput...)
 	}
@@ -177,7 +216,7 @@ func (t *tailCmd) Run(ctx *context) error {
 
 	triggerChannels := make([]chan<- time.Time, len(t.LogGroupStreamName))
 
-	coordinator := &tailCoordinator{log: ctx.Log}
+	coordinator := &tailCoordinator{log: ctx.DebugLog}
 	for idx, gs := range t.LogGroupStreamName {
 		trigger := make(chan time.Time, 1)
 		go func(groupStream string) {
@@ -187,7 +226,16 @@ func (t *tailCmd) Run(ctx *context) error {
 			if len(tokens) > 1 && tokens[1] != "*" {
 				prefix = tokens[1]
 			}
-			ch, e := cloudwatch.Tail(&ctx.Client, &group, &prefix, &t.Follow, &t.Retry, &st, &et, &t.Grep, &t.Grepv, trigger, ctx.Log)
+			ch, e := cloudwatch.Tail(&ctx.Client, cloudwatch.TailConfig{
+				LogGroupName:  &group,
+				LogStreamName: &prefix,
+				Follow:        &t.Follow,
+				Retry:         &t.Retry,
+				StartTime:     &st,
+				EndTime:       &et,
+				Grep:          &t.Grep,
+				Grepv:         &t.Grepv,
+			}, trigger, ctx.DebugLog)
 			if e != nil {
 				fmt.Fprintln(os.Stderr, e.Error())
 				os.Exit(1)
@@ -206,13 +254,31 @@ func (t *tailCmd) Run(ctx *context) error {
 
 	go func() {
 		wg.Wait()
-		ctx.Log.Println("closing main channel...")
+		ctx.DebugLog.Println("closing main channel...")
 
 		close(out)
 	}()
 
+	config := formatConfig{
+		PrintTime:       t.PrintTimeStamp,
+		PrintStreamName: t.PrintStreamName,
+		PrintGroupName:  t.PrintGroupName,
+		PrintEventID:    t.PrintEventID,
+	}
+	if t.Query != "" {
+		query, err := jmespath.Compile(t.Query)
+		if err != nil {
+			return fmt.Errorf("Failed to parse query as JMESPath query. Query: \"%s\", error: \"%w\"", t.Query, err)
+		}
+		config.Query = query
+	}
+
+	formatter := logEventFormatter{
+		FormatConfig: config,
+		Log:          ctx.DebugLog}
+
 	for logEv := range out {
-		fmt.Println(formatLogMsg(*logEv, &t.PrintTimeStamp, &t.PrintStreamName, &t.PrintGroupName, &t.PrintEventID))
+		fmt.Println(formatter.formatLogMsg(*logEv))
 	}
 	return nil
 }
@@ -222,7 +288,7 @@ type lsCmd struct {
 	LsStreamsCmd lsStreamsCmd `cmd name:"streams" help:"Show all streams in a given log group."`
 }
 
-func (l *lsStreamsCmd) Run(ctx *context) error {
+func (l *lsStreamsCmd) Run(ctx *appContext) error {
 	foundStreams, errorsCh := cloudwatch.LsStreams(&ctx.Client, &l.GroupName, aws.String(""))
 	for {
 		select {
@@ -249,7 +315,7 @@ func (l *lsStreamsCmd) Run(ctx *context) error {
 	}
 }
 
-func (r *lsGroupsCmd) Run(ctx *context) error {
+func (r *lsGroupsCmd) Run(ctx *appContext) error {
 	for msg := range cloudwatch.LsGroups(&ctx.Client) {
 		fmt.Println(*msg)
 	}
@@ -280,16 +346,16 @@ func main() {
 		kong.Name("cw"),
 		kong.Description("The best way to tail AWS Cloudwatch Logs from your terminal."))
 
-	log := log.New(ioutil.Discard, "", log.LstdFlags)
+	debugLog := log.New(ioutil.Discard, "cw [debug] ", log.LstdFlags)
 	if cli.Debug {
-		log.SetOutput(os.Stderr)
-		log.Println("Debug mode is on.")
+		debugLog.SetOutput(os.Stderr)
+		debugLog.Println("Debug mode is on. Will print debug messages to stderr")
 	}
 
 	if *&cli.NoColor {
 		color.NoColor = true
 	}
-	client := cloudwatch.New(&cli.AwsEndpointURL, &cli.AwsProfile, &cli.AwsRegion, log)
-	err := ctx.Run(&context{Debug: cli.Debug, Client: *client, Log: log})
+	client := cloudwatch.New(&cli.AwsEndpointURL, &cli.AwsProfile, &cli.AwsRegion, debugLog)
+	err := ctx.Run(&appContext{Debug: cli.Debug, Client: *client, DebugLog: debugLog})
 	ctx.FatalIfErrorf(err)
 }


### PR DESCRIPTION
This matches the AWS client side --query parameter:
https://docs.aws.amazon.com/cli/latest/userguide/cli-usage-filter.html#cli-usage-filter-client-side.

This is supported in the python equivalent: https://github.com/jorgebastida/awslogs.

See https://jmespath.org/ for a full idea of what this allows.

The current behaviour:
* fails prior to tailing if the JMESpath expressions fails to compile
* returns the full logs line if the JMESpath query fails to run

_I'll admit I haven't vigorously tested this as I have a lack of AWS credentials on this computer, and a lack of JSON logs to test on. I can check further this week_