### PR TITLE
Fix source command in output for brew

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -50,7 +50,7 @@ brews:
           [bash] you need to install `bash-completion` with brew.
           OR
           [zsh], add the following line to your ~/.zshrc:
-            source #{HOMEBREW_PREFIX}/share/zsh/site-functions/cw"
+            source #{HOMEBREW_PREFIX}/share/zsh/site-functions/cw.zsh"
     install: |
       bin.install "cw"
 


### PR DESCRIPTION
The source command for zsh completion coming from stdout when installing via brew is incorrect. 