### PR TITLE
Update docs on AWS SSO

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,10 +206,14 @@ Use the `--local` flag if you prefer to use Local zone.
 
 ### AWS SSO
 
-As today (May 2020) AWS Go SDK is not supporting AWS SSO correctly.
-The best approach is to use one of these tools while the SDK is updated:
-<https://github.com/benkehoe/aws-sso-credential-process>
-<https://github.com/victorskl/yawsso>
+AWS SSO is supported if you:
+
+* use a CLI profile (either `default` or an alternate named profile) that includes the various SSO properties
+  * `sso_start_url`, `sso_account_id`, `sso_role_name`, etc
+* have a valid, active SSO session
+  * via `aws sso login`
+
+If you get an error message that includes `...failed to sign request: failed to retrieve credentials: the SSO session has expired or is invalid...` then you should renew your SSO session via `aws sso login` (and specify the named profile, if appropriate).
 
 ## Miscellaneous
 


### PR DESCRIPTION
My org is adopting AWS SSO and we use this tool, so I thought I’d check
whether the info here in the README was still accurate.

My SSO profile does include the property `credential_process` but for
the purposes of this test I commented it out, because I wanted to see if
the version of the AWS SDK that this program is currently using would
support SSO sessions directly, rather than via `credential_process`.

I made sure I had a valid and working SSO profile and session via
`aws sso login` and `aws s3 ls` which both succeeded.

Then I ran `cw ls groups --profile <my-profile>` and it succeeded — the
program printed a list of groups.

This is with cw 4.1.1, installed via Homebrew from the tap, as per the
docs, on MacOS 12.3.1 on an Apple Silicon (ARM64/aarch64) Mac.