### PR TITLE
add no-version-check flag to ignore version check at startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ go get github.com/lucagrulla/cw
 -   `--region=aws-region` Override the target AWS region.
 -   `--no-color` Disable coloured output.
 -   `--endpoint` The target AWS endpoint url. By default cw will use the default aws endpoints.
+-   `--no-version-check` Ignore checks if a newer version of the module is available.
 
 ### Commands
 
@@ -126,6 +127,7 @@ go get github.com/lucagrulla/cw
                               .aws/credentials file. NOTE: v4.0.0 dropped the flag short version.
           --no-color           Disable coloured output.NOTE: v4.0.0 dropped the flag short version.
           --version            Print version information and quit
+          --no-version-check   Ignore checks if a newer version of the module is available.
 
     Commands:
       ls groups
@@ -155,6 +157,7 @@ go get github.com/lucagrulla/cw
           --region=REGION                  The target AWS region. By default cw will use the default region defined in the .aws/credentials file. NOTE: v4.0.0 dropped the flag short version.
           --no-color                       Disable coloured output.NOTE: v4.0.0 dropped the flag short version.
           --version                        Print version information and quit
+          --no-version-check               Ignore checks if a newer version of the module is available.
 
       -f, --follow                         Don't stop when the end of streams is reached, but rather wait for additional data to be appended.
       -t, --timestamp                      Print the event timestamp.

--- a/main.go
+++ b/main.go
@@ -333,6 +333,7 @@ var cli struct {
 	AwsProfile     string           `help:"The target AWS profile. By default cw will use the default profile defined in the .aws/credentials file. NOTE: v4.0.0 dropped the flag short version." name:"profile" placeholder:"PROFILE"`
 	AwsRegion      string           `name:"region" help:"The target AWS region. By default cw will use the default region defined in the .aws/credentials file. NOTE: v4.0.0 dropped the flag short version." placeholder:"REGION"`
 	NoColor        bool             `name:"no-color" help:"Disable coloured output.NOTE: v4.0.0 dropped the flag short version. " default:"false"`
+	NoVersionCheck bool             `name:"no-version-check" help:"Ignore checks if a newer version of the module is available. " default:"false"`
 	Version        kong.VersionFlag `name:"version" help:"Print version information and quit"`
 
 	Ls   lsCmd   `cmd help:"show an entity"`
@@ -340,9 +341,6 @@ var cli struct {
 }
 
 func main() {
-
-	defer newVersionMsg(version, fetchLatestVersion())
-	go versionCheckOnSigterm()
 
 	ctx := kong.Parse(&cli,
 		kong.Vars{"now": time.Now().UTC().Add(-45 * time.Second).Format(timeFormat), "version": version},
@@ -354,6 +352,11 @@ func main() {
 	if cli.Debug {
 		debugLog.SetOutput(os.Stderr)
 		debugLog.Println("Debug mode is on. Will print debug messages to stderr")
+	}
+
+	if !cli.NoVersionCheck {
+		defer newVersionMsg(version, fetchLatestVersion())
+		go versionCheckOnSigterm()	
 	}
 
 	if *&cli.NoColor {


### PR DESCRIPTION
Hello there,

I hope this message finds you well.
I came across your repository and noticed an opportunity to contribute.
I have made some changes and additions that I think could improve the functionality and overall user experience of your project.
I have submitted a pull request and I would be happy to discuss any feedback or concerns you may have.
Thank you for your time and consideration, and I look forward to potentially contributing more to your project in the future.

Best regards,
ioroioroi


## Problem
When using cw on an intranet where https://github.com is not reachable (but AWS is), github access via `fetchLatestVersion` waits until the timeout.
I thought that this would detract from the portability benefits of cw being go-binary, and wanted to address this.


## Proposal
I thought it would be good to add `--no-version-check` to the global flag, so that users can skip the version check optionally.
i.e. `cw ls groups --no-version-check` will get the log group list without version checking.
